### PR TITLE
Fixed #7. The alert appeared behind the keyboard.

### DIFF
--- a/Source/SPAlert/SPAlertView.swift
+++ b/Source/SPAlert/SPAlertView.swift
@@ -58,7 +58,7 @@ open class SPAlertView: UIView {
         }
     }
     
-    private var keyWindow: UIWindow { return UIApplication.shared.keyWindow ?? UIWindow() }
+    public var keyWindow: UIView = (UIApplication.shared.keyWindow ?? UIWindow())
     
     //MARK: - Initializers
     
@@ -175,6 +175,7 @@ open class SPAlertView: UIView {
         
         self.keyWindow.addSubview(self)
         self.layoutIfNeeded()
+        self.layoutSubviews()
         self.alpha = 0
         self.transform = transform.scaledBy(x: 0.8, y: 0.8)
         


### PR DESCRIPTION
Made `keyWindow` public so users can set their own parent view. This allows anyone to apply keyboard constraints as they want to.

An example how a user could use this;

```
import UIKit
import SPAlert

class ViewController: UIViewController {

    @IBOutlet weak var inputField: UITextField!
    
    @IBOutlet weak var wrapperView: UIView!
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        // attachKeyboardConstraint()
        
        inputField.becomeFirstResponder()
    }

    @IBAction func textField(_ sender: Any) {
        let alertView = SPAlertView(title: "Added to Library", message: nil, preset: SPAlertPreset.done)
        alertView.keyWindow = wrapperView
        alertView.present()
    }
    
}
```