### PR TITLE
Better init for SPAlert with preset only

### DIFF
--- a/Sources/SPAlert/SPAlertView.swift
+++ b/Sources/SPAlert/SPAlertView.swift
@@ -108,7 +108,11 @@ open class SPAlertView: UIView {
         super.init(frame: CGRect.zero)
         commonInit()
         setIcon(for: preset)
-        layout = SPAlertLayout(for: preset)
+        layout = SPAlertLayout(
+            iconSize: CGSize(width: 16, height: 16),
+            margins: UIEdgeInsets(top: 58, left: 16, bottom: 58, right: 58),
+            spaceBetweenIconAndTitle: 0
+        )
         switch preset {
         case .spinner:
             dismissInTime = false
@@ -122,11 +126,7 @@ open class SPAlertView: UIView {
     public init(message: String) {
         super.init(frame: CGRect.zero)
         commonInit()
-        layout = SPAlertLayout(
-            iconSize: CGSize(width: 16, height: 16),
-            margins: UIEdgeInsets(top: 58, left: 16, bottom: 58, right: 58),
-            spaceBetweenIconAndTitle: 0
-        )
+        layout = SPAlertLayout.message()
         setMessage(message)
         dismissInTime = true
         dismissByTap = true

--- a/Sources/SPAlert/SPAlertView.swift
+++ b/Sources/SPAlert/SPAlertView.swift
@@ -107,13 +107,26 @@ open class SPAlertView: UIView {
     public init(preset: SPAlertIconPreset) {
         super.init(frame: CGRect.zero)
         commonInit()
+        setIcon(for: preset)
         layout = SPAlertLayout(for: preset)
+        switch preset {
+        case .spinner:
+            dismissInTime = false
+            dismissByTap = false
+        default:
+            dismissInTime = true
+            dismissByTap = true
+        }
     }
     
     public init(message: String) {
         super.init(frame: CGRect.zero)
         commonInit()
-        layout = SPAlertLayout.message()
+        layout = SPAlertLayout(
+            iconSize: CGSize(width: 16, height: 16),
+            margins: UIEdgeInsets(top: 58, left: 16, bottom: 58, right: 58),
+            spaceBetweenIconAndTitle: 0
+        )
         setMessage(message)
         dismissInTime = true
         dismissByTap = true


### PR DESCRIPTION
## Goal
Preset color was not defined and layout was wrong (top margin > bottom margin, preset not centered).

## Checklist
- [x] Testing in compability platforms
- [x] Installed correct via `Swift Package Manager` and `Cocoapods`
